### PR TITLE
enhancement #3: Add currency sign (acronym) support

### DIFF
--- a/DAL/Entities/Сurrency.cs
+++ b/DAL/Entities/Сurrency.cs
@@ -8,7 +8,8 @@ namespace DAL.Entities
         [Required]
         public string Name { get; set; } = null!;
 
-        // add Currency sign
+        [Required]
+        public string Acronym { get; set; } = null!;
 
         public List<Transaction> Transactions { get; set; } = null!;
     }

--- a/DAL/Migrations/20240307124654_currency-acronym.Designer.cs
+++ b/DAL/Migrations/20240307124654_currency-acronym.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DAL.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DAL.Migrations
 {
     [DbContext(typeof(SMDbContext))]
-    partial class SMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240307124654_currency-acronym")]
+    partial class currencyacronym
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DAL/Migrations/20240307124654_currency-acronym.cs
+++ b/DAL/Migrations/20240307124654_currency-acronym.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DAL.Migrations
+{
+    /// <inheritdoc />
+    public partial class currencyacronym : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Acronym",
+                table: "Currencies",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Acronym",
+                table: "Currencies");
+        }
+    }
+}


### PR DESCRIPTION
Desided to not store currency sign due to locale differences: different signs and their placements.
- Currency changed
- migration applied